### PR TITLE
Potential fix for code scanning alert no. 1: Binding a socket to all network interfaces

### DIFF
--- a/src/mcp_foxxy_bridge/mcp_server.py
+++ b/src/mcp_foxxy_bridge/mcp_server.py
@@ -98,7 +98,7 @@ def _find_available_port(host: str, requested_port: int) -> int:
 
     # If we exhausted all attempts, fall back to system-assigned port
     with socket.socket() as s:
-        s.bind(("", 0))
+        s.bind((host, 0))
         actual_port = s.getsockname()[1]
     logger.warning(
         "Could not find available port in range %d-%d, using system-assigned port %d",


### PR DESCRIPTION
Potential fix for [https://github.com/billyjbryant/mcp-foxxy-bridge/security/code-scanning/1](https://github.com/billyjbryant/mcp-foxxy-bridge/security/code-scanning/1)

To fix the issue, we should replace the empty string `""` in `s.bind(("", 0))` with a specific host address. Since the function `_find_available_port` already accepts a `host` parameter, we can use this parameter to bind the socket to the specified interface. This ensures that the socket is only accessible through the intended network interface.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
