### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -409,6 +409,8 @@ jobs:
           });
 
   maintenance-summary:
+    permissions:
+      contents: write
     needs: [detect-changes, setup-labels, validate-config-changes]
     runs-on: ubuntu-latest
     if: always() && github.event_name == 'push'


### PR DESCRIPTION
Potential fix for [https://github.com/billyjbryant/mcp-foxxy-bridge/security/code-scanning/7](https://github.com/billyjbryant/mcp-foxxy-bridge/security/code-scanning/7)

To fix the problem, add a `permissions` block to the `maintenance-summary` job in `.github/workflows/maintenance.yml`. The minimal required permission for this job is `contents: write`, as it creates a commit comment using the GitHub API. The `permissions` block should be added directly under the job name (`maintenance-summary:`), before the `needs:` key. No other changes are needed, and no new imports or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
